### PR TITLE
Deliveries changed to Static Content (none php or executable code are…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,13 +30,15 @@ return array(
     'label'          => 'Synchronization Client',
     'description'    => 'Synchronization logic specific only for the client server',
     'license'        => 'GPL-2.0',
-    'version'        => '1.1.0',
+    'version'        => '2.0.0',
     'author'         => 'Open Assessment Technologies SA',
     'requires'       => array(
-        'tao'           => '>=37.1.1',
-        'taoLti'        => '>=10.1.0',
-        'taoProctoring' => '>=16.4.0',
-        'taoPublishing' => '>=2.1.1'
+        'tao'               => '>=37.1.1',
+        'taoLti'            => '>=10.1.0',
+        'taoProctoring'     => '>=16.4.0',
+        'taoPublishing'     => '>=2.1.1',
+        'taoDeliveryRdf'    => '>=9.1.0',
+        'taoQtiTest'        => '>=34.10.0',
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoSyncClientManager',
     'acl'            => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -24,6 +24,10 @@ namespace oat\taoSyncClient\scripts\update;
 
 use common_ext_ExtensionUpdater;
 use common_report_Report;
+use oat\taoDeliveryRdf\model\import\AssemblerService;
+use oat\taoDeliveryRdf\model\import\StaticAssemblerService;
+use oat\taoQtiTest\models\CompilationDataService;
+use oat\taoQtiTest\models\XmlCompilationDataService;
 use oat\taoSyncClient\model\dataProvider\providers\DeliveryLogDataProviderService;
 use oat\taoSyncClient\model\dataProvider\providers\LtiUserDataProviderService;
 use oat\taoSyncClient\model\dataProvider\providers\ResultsDataProviderService;
@@ -72,5 +76,19 @@ class Updater extends common_ext_ExtensionUpdater
         }
 
         $this->skip('1.0.0', '1.1.0');
+
+        if ($this->isVersion('1.1.0')) {
+
+            // rewrite AssemblerService to import deliveries with static content (manifest runtime is json now instead of serialized php)
+            $options = $this->getServiceManager()->get(AssemblerService::SERVICE_ID)->getOptions();
+            $service = new StaticAssemblerService($options);
+            $this->getServiceManager()->register(AssemblerService::SERVICE_ID, $service);
+
+            // rewrite CompilationDataService to use xml files instead of php (compact-test.php)
+            $options = $this->getServiceManager()->get(CompilationDataService::SERVICE_ID)->getOptions();
+            $this->getServiceManager()->register(CompilationDataService::SERVICE_ID, new XmlCompilationDataService($options));
+
+            $this->setVersion('2.0.0');
+        }
     }
 }


### PR DESCRIPTION
… stored in the compiled delivery files)

### Compile delivery without executable code
 
Related to: https://oat-sa.atlassian.net/browse/TAO-8584
 
Added StaticAssemblerService which extends AssemblerService and converts all executable code in the qti to the non-executable analogs (compact-test.php to compact-test.xml and serialized runtime to the json runtime)
 
#### How to test
 
Just run a CLI command to get new zip archive (from the taoEncryption extension)
 
Test commands :
 
```
php index.php 'oat\taoEncryption\scripts\tools\DeliveryAssembly\ExportEncryptedAssembly' -uri 'http://sample/first.rdf\#i15728722651806332' -key 1 -s 1
```
  
#### Dependencies
 
Requires:
 - [ ] https://github.com/oat-sa/extension-tao-delivery-rdf/pull/288